### PR TITLE
Support using condition variables

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -142,18 +142,6 @@ jobs:
               os: windows-latest,
               compiler: { type: VISUAL, version: 19, cc: "cl", cxx: "cl" },
             }
-          - {
-              name: "MacOS Apple Clang 15",
-              os: macos-14,
-              compiler:
-                {
-                  type: APPLE_CLANG,
-                  version: "15.0",
-                  cc: "clang",
-                  cxx: "clang++",
-                  std: 20,
-                },
-            }
     steps:
       - uses: actions/checkout@v4
       - uses: seanmiddleditch/gha-setup-ninja@master

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -66,6 +66,27 @@ the standard library header `<mutex>`.
 
 ## Choices
 
+### Using `lock_guard` or `unique_lock`
+
+Calling `lock` unconditionally locks the mutex, so intuitively it should return a
+`lock_guard`, which is slightly faster than `unique_lock`, which needs to check if
+the lock is held at destruction. The problem with this is that `lock_guard` is
+incompatible with `condition_variable`, which only accept a `unique_lock`.
+Alternatively we could expose the mutex and force people to use
+`condition_variable_any`, but `lock_guard` doesn't expose `mutex` either. We could
+package an extra reference to the underlying mutex, but that would cost additional
+memory (unless the optimizer removes the unused reference).
+
+It seems returning a `unique_lock` is low enough cost to not be a big deal and
+worth the additional compabitility. If the cost is too high, then you can avoid it
+by using `with` instead of `lock`. Since the guard isn't exposed and therefore
+can't be used with a condition variable `with` uses `lock_guard` for the additional
+speed.
+
+One other minor argument for always using a `unique_lock` is so that the return
+type doesn't change if you switch from `lock` to `try_lock`, where `unique_lock`
+is needed.
+
 ### Explicit or overloaded method names
 
 Is it better to be explicit with all the variants, or use overloads? We've
@@ -82,7 +103,7 @@ though the templates, namespaces, `[[nodiscard]]` and concept constraints have
 been ommited for clarity.
 
 ```c++
-  mutex_locked<T, lock_guard<M>> lock();
+  mutex_locked<T, unique_lock<M>> lock();
   mutex_locked<T, unique_lock<M>> try_lock();
   mutex_locked<T, unique_lock<M>> try_lock_until(const time_point &timeout_time);
   mutex_locked<T, unique_lock<M>> try_lock_for(const duration &timeout_duration);
@@ -111,7 +132,7 @@ The alternative is to use overloads. A potential api is below, with the same
 simplifications as above.
 
 ```c++
-  mutex_locked<T, lock_guard<M>> lock();
+  mutex_locked<T, unique_lock<M>> lock();
   mutex_locked<T, unique_lock<M>> lock(const time_point &timeout_time);
   mutex_locked<T, unique_lock<M>> lock(const duration &timeout_duration);
 
@@ -137,7 +158,7 @@ support `try_lock` on a `std::mutex`. This suggests an alternative in
 between may be more reasonable:
 
 ```c++
-  mutex_locked<T, lock_guard<M>> lock();
+  mutex_locked<T, unique_lock<M>> lock();
   mutex_locked<T, unique_lock<M>> try_lock();
   mutex_locked<T, unique_lock<M>> try_lock(const time_point &timeout_time);
   mutex_locked<T, unique_lock<M>> try_lock(const duration &timeout_duration);

--- a/mutex_protected.h
+++ b/mutex_protected.h
@@ -73,7 +73,7 @@ class [[nodiscard]] mutex_locked {
 
   mutex_locked(mutex_locked &&m) noexcept
     requires std::move_constructible<G>
-      : v(std::exchange(m.v, nullptr)), guard(std::move(m.guard)) {}
+      : v(std::exchange(m.v, nullptr)), g(std::move(m.g)) {}
 
   // Needed for use with `std::condition_variable_any`, ie if you are using a
   // different mutex type.

--- a/mutex_protected.h
+++ b/mutex_protected.h
@@ -60,7 +60,7 @@ class [[nodiscard]] mutex_locked {
     return g.owns_lock();
   }
 
-  // Needed so that the lock guard can be used in a condition variable.
+  // Needed for use with `std::condition_variable`.
   G &guard() noexcept
     requires std::is_same_v<G, std::unique_lock<std::mutex>>
   {
@@ -74,6 +74,14 @@ class [[nodiscard]] mutex_locked {
   mutex_locked(mutex_locked &&m) noexcept
     requires std::move_constructible<G>
       : v(std::exchange(m.v, nullptr)), guard(std::move(m.guard)) {}
+
+  // Needed for use with `std::condition_variable_any`, ie if you are using a
+  // different mutex type.
+  mutex_type *mutex() noexcept
+    requires std::is_member_function_pointer_v<decltype(&G::mutex)>
+  {
+    return g.mutex();
+  }
 
  private:
   template <typename... Args>

--- a/mutex_protected_test.cc
+++ b/mutex_protected_test.cc
@@ -1,6 +1,7 @@
 #include "mutex_protected.h"
 
 #include <chrono>
+#include <condition_variable>
 #include <queue>
 #include <string>
 #include <thread>

--- a/mutex_protected_test.cc
+++ b/mutex_protected_test.cc
@@ -478,6 +478,7 @@ TEST(CondVarMutexProtectedTest, ConditionVariableWorks) {
 TEST(CondVarMutexProtectedTest, ConditionVariableAnyWorks) {
   mutex_protected<int, std::shared_mutex> data = 0;
   std::condition_variable_any cv;
+  mutex_protected<int> out = 0;
 
   const int thread_count = 2;
 
@@ -488,6 +489,7 @@ TEST(CondVarMutexProtectedTest, ConditionVariableAnyWorks) {
       auto locked = data.lock_shared();
       cv.wait(*locked.mutex(), [&locked]() { return *locked > 0; });
       EXPECT_EQ(*locked, 1);
+      *out.lock() += *locked;
     });
   }
 
@@ -497,6 +499,7 @@ TEST(CondVarMutexProtectedTest, ConditionVariableAnyWorks) {
   for (auto& thread : threads) {
     thread.join();
   }
+  EXPECT_EQ(*out.lock(), thread_count);
 }
 
 }  // namespace xyz


### PR DESCRIPTION
This supports both `std::condition_variable` and `std::condition_variable_any`. The downside is that it requires using `std::unique_lock` instead of `std::lock_guard` for `lock`, though using `with` lets you keep the speed of `std::lock_guard`.