### PR TITLE
xyz::lock -> xyz::lock_protected, to not overload std::lock with a different return type.

### DIFF
--- a/mutex_protected.h
+++ b/mutex_protected.h
@@ -238,17 +238,18 @@ class mutex_protected {
   M mutex;
   T v;
 
-  // Used by `xyz::lock` when locking multiple mutex_protected objects.
+  // Used by `xyz::lock_protected` when locking multiple mutex_protected
+  // objects.
   mutex_locked<T, std::unique_lock<M>> adopt_lock() {
     return mutex_locked<T, std::unique_lock<M>>(&v, mutex, std::adopt_lock);
   }
 
   template <typename... MutexProtected>
-  friend auto lock(MutexProtected &...mp);
+  friend auto lock_protected(MutexProtected &...mp);
 };
 
 template <typename... MutexProtected>
-auto lock(MutexProtected &...mps) {
+auto lock_protected(MutexProtected &...mps) {
   std::lock(mps.mutex...);
   return std::make_tuple(mps.adopt_lock()...);
 }

--- a/mutex_protected_test.cc
+++ b/mutex_protected_test.cc
@@ -172,14 +172,14 @@ TYPED_TEST(MutexProtectedTest, LockMultiple) {
   mutex_protected<int, TypeParam> a(1);
   mutex_protected<int, TypeParam> b(2);
   {
-    auto [la, lb] = xyz::lock(a, b);
+    auto [la, lb] = xyz::lock_protected(a, b);
     EXPECT_EQ(*la, 1);
     EXPECT_EQ(*lb, 2);
     *la += 10;
     *lb += 10;
   }
   {
-    auto [lb, la] = xyz::lock(b, a);
+    auto [lb, la] = xyz::lock_protected(b, a);
     EXPECT_EQ(*la, 11);
     EXPECT_EQ(*lb, 12);
   }


### PR DESCRIPTION
Related to #16 